### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_login, only: [:new, :create]
+  before_action :set_item, only: [:show]
 
   def index
     @items = Item.all.order(id: "DESC")
@@ -18,6 +19,9 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+  end
+
   private
 
   def item_params
@@ -27,5 +31,9 @@ class ItemsController < ApplicationController
 
   def move_to_login
     redirect_to new_user_session_path unless user_signed_in?
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,9 +130,8 @@
     <% if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "" %>
         <div class='item-img-content'>
-          <%= image_tag item.item_image, class: "item-img" %>
+          <%= link_to image_tag( item.item_image, class: "item-img"), item_path(item.id), method: :get %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,7 +135,7 @@
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
-            <span>Sold Out!!</span>
+          <%#  <span>Sold Out!!</span> %>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,12 +26,11 @@
     </div>
 
     
-    <% if user_signed_in? && current_user.id == @item.user.id %>
+    <% if current_user.id == @item.user.id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% end %>
-    <% if user_signed_in? && current_user.id != @item.user.id %>
+    <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,68 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.item_image, class:"item-box-img" %>
+      
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.delivery_charge[:name] %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user.id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <% end %>
+    <% if user_signed_in? && current_user.id != @item.user.id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_charge[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_day[:name] %></td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +105,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category[:name] %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -11,7 +11,7 @@
       
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
-        <span>Sold Out!!</span>
+      <%#  <span>Sold Out!!</span> %>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
     <% if user_signed_in? && current_user.id == @item.user.id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
@@ -36,7 +36,7 @@
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
 
     <div class="item-explain-box">
       <span><%= @item.item_explanation %></span>
@@ -104,9 +104,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
   <a href="#" class="another-item"><%= @item.category[:name] %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
What  
トップページの商品一覧から、選択した商品の詳細ページへ遷移するように記述。
ログイン、ログアウト、出品者で選択できる項目の表示が変わるように記述  
Why  
商品詳細表示機能の実装を行うため

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/4264d03a4868a5339f68dae3cbad1f7c

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/69cfd6d3a844dae781acff27f2f2c42c

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/262687f48ecf1b746cb7967b9a1c7991